### PR TITLE
ws as library instead of socketio

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var EventEmitter = require("events").EventEmitter;
 var Changeset = require('./Changeset');
 var AttributePool = require('./AttributePool');
 var assert = require('assert');
+const WebSocket = require('ws');
 
 exports.connect = function(host){
 
@@ -23,18 +24,16 @@ exports.connect = function(host){
     padState.padId = parsed.pathname.replace("/p/", "");
   }
 
-  // Connect to Socket
-  var socket = require('socket.io-client')(padState.host, {
-    "forceNew": true,
-    "timeout": 1000,
-    "force new connection": true
-  });
+  padState.hostWS = padState.host.replace("https:", "");
+  padState.hostWS = padState.hostWS.replace("http:", "");
+
+  const ws = new WebSocket('ws://'+padState.hostWS);
 
   // On connection send Client ready data
-  socket.on('connect', function(data){
+  ws.on('open', function(data){
 
     sessionID = randomString();
-    token = randomString(); 
+    token = randomString();
     // TODO - Not sure if this is needed but needs to be unique
     // else Etherpad will think multiple connections are one client
 
@@ -48,10 +47,10 @@ exports.connect = function(host){
       "protocolVersion": 2
     };
 
-    socket.json.send(msg);
+    ws.json.send(msg);
   });
 
-  socket.on('message', function(obj){
+  ws.on('message', function incoming(obj){
     // message emitter sends all messages should they be required
     ee.emit('message', obj);
 
@@ -132,15 +131,15 @@ exports.connect = function(host){
 
   });
 
-  socket.on("disconnect", function(e){
+  ws.on("disconnect", function(e){
     ee.emit("disconnect", e);
   });
 
-  socket.on("connect_timeout", function(e){
+  ws.on("connect_timeout", function(e){
     ee.emit("connect_timeout", e);
   });
 
-  socket.on("connect_error", function(e){
+  ws.on("connect_error", function(e){
     ee.emit("connect_error", e);
   });
 
@@ -196,7 +195,7 @@ exports.connect = function(host){
     if(!padState.inFlight && padState.outgoing) {
       padState.inFlight = padState.outgoing;
       padState.outgoing = null;
-      socket.json.send({
+      ws.json.send({
         type: "COLLABROOM",
         component: "pad",
         data: JSON.parse(JSON.stringify(padState.inFlight))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "etherpad-cli-client",
+  "version": "0.0.11",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,22 +7,24 @@
     "email": "john@mclear.co.uk",
     "url": "http://mclear.co.uk"
   },
-  "contributors": [{
-    "name": "Dmitry Uvarov",
-    "email":"uvarov.dl@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Dmitry Uvarov",
+      "email": "uvarov.dl@gmail.com"
+    }
+  ],
   "dependencies": {
-    "socket.io-client":"*",
-    "async":"*"
+    "async": "*",
+    "ws": "^7.3.1"
   },
   "engines": {
     "node": "*"
   },
-  "repository" : {
-    "type" : "git",
-    "url"  : "https://github.com/johnmclear/etherpad-cli-client.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/johnmclear/etherpad-cli-client.git"
   },
-  "bin":{
-    "etherpad":"cli.js"
+  "bin": {
+    "etherpad": "cli.js"
   }
 }


### PR DESCRIPTION
First thing to test will be the etherpad-load-test tool which consumes this library so this will need merging if uws works out.  For now it can just sit here because porting from socketio to uws will be time consuming...

uws doesn't offer a node client so Alex recommends using ws: https://github.com/uNetworking/uWebSockets.js/issues/46