### PR TITLE
downgrad socket.io-client dependency to 2.3.0 until we can update to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "email":"uvarov.dl@gmail.com"
   }],
   "dependencies": {
-    "socket.io-client":"*",
+    "socket.io-client":"^2.3.0",
     "async":"*"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "etherpad-cli-client",
   "description": "Node Client for Etherpad",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": {
     "name": "John McLear",
     "email": "john@mclear.co.uk",


### PR DESCRIPTION
workaround so that our travis tests for ratelimit and loadtest work again